### PR TITLE
1491 refactor

### DIFF
--- a/politeiad/backendv2/tstorebe/plugins/pi/hooks.go
+++ b/politeiad/backendv2/tstorebe/plugins/pi/hooks.go
@@ -136,10 +136,8 @@ func (p *piPlugin) hookPluginPre(payload string) error {
 	return nil
 }
 
-
-// titleIsValid returns whether the provided title, which can be
-// either a proposal name or an author update title, matches the pi plugin
-// title regex.
+// titleIsValid returns whether the provided title, which can be either a
+// proposal name or an author update title, matches the pi plugin title regex.
 func (p *piPlugin) titleIsValid(title string) bool {
 	return p.titleRegexp.MatchString(title)
 }

--- a/politeiad/backendv2/tstorebe/plugins/pi/hooks.go
+++ b/politeiad/backendv2/tstorebe/plugins/pi/hooks.go
@@ -136,8 +136,8 @@ func (p *piPlugin) hookPluginPre(payload string) error {
 	return nil
 }
 
-// proposalNameIsValid returns whether the provided title which can be
-// either a proposal name or an author update title matches the pi plugin
+// proposalNameIsValid returns whether the provided title, which can be
+// either a proposal name or an author update title, matches the pi plugin
 // title regex.
 func (p *piPlugin) titleIsValid(title string) bool {
 	return p.titleRegexp.MatchString(title)
@@ -322,7 +322,7 @@ func (p *piPlugin) proposalFilesVerify(files []backend.File) error {
 	if !p.titleIsValid(pm.Name) {
 		return backend.PluginError{
 			PluginID:     pi.PluginID,
-			ErrorCode:    uint32(pi.ErrorCodeProposalNameInvalid),
+			ErrorCode:    uint32(pi.ErrorCodeTitleInvalid),
 			ErrorContext: p.titleRegexp.String(),
 		}
 	}
@@ -480,61 +480,65 @@ func (p *piPlugin) commentVoteAllowedOnApprovedProposal(token []byte, payload st
 	if !isInCommentTree(latestAuthorUpdate.CommentID, v.CommentID, cs) {
 		return backend.PluginError{
 			PluginID:  pi.PluginID,
-			ErrorCode: uint32(pi.ErrorCodeWritesAllowedOnlyOnUpdates),
+			ErrorCode: uint32(pi.ErrorCodeCommentWriteNotAllowed),
+			ErrorContext: "votes are only allowed on the author's " +
+				"most recent update thread",
 		}
 	}
 
 	return nil
 }
 
-// isValidAuthorUpdate returns whether the given new comment is a valid
-// author update.
-// Comment must include proper proposal update metadata and it's author
-// must be the proposal's author for it to be considered as a valid
+// isValidAuthorUpdate returns whether the given new comment is a valid author
+// update.
+//
+// The comment must include proper proposal update metadata and the comment
+// must be submitted by the proposal author for it to be considered a valid
 // author update.
 func (p *piPlugin) isValidAuthorUpdate(token []byte, n comments.New) error {
-	// Get proposal author to ensure new comment's author is
-	// the proposal's author.
+	// Get the proposal author. The proposal author
+	// and the comment author must be the same user.
 	recordAuthorID, err := p.recordAuthor(token)
 	if err != nil {
 		return err
 	}
-
-	if n.UserID == recordAuthorID &&
-		n.ExtraData != "" && n.ExtraDataHint != "" {
-		switch n.ExtraDataHint {
-		case pi.ProposalUpdateHint:
-			// Decode comment extra data
-			var pum pi.ProposalUpdateMetadata
-			err = json.Unmarshal([]byte(n.ExtraData), &pum)
-			if err != nil {
-				return err
-			}
-			// Verify update title
-			if !p.titleIsValid(pum.Title) {
-				return backend.PluginError{
-					PluginID:     pi.PluginID,
-					ErrorCode:    uint32(pi.ErrorCodeUpdateTitleInvalid),
-					ErrorContext: p.titleRegexp.String(),
-				}
-			}
-			// New valid author update
-			return nil
-
-		default:
-			return backend.PluginError{
-				PluginID:  pi.PluginID,
-				ErrorCode: uint32(pi.ErrorCodeExtraDataHintInvalid),
-			}
-
+	if recordAuthorID != n.UserID {
+		return backend.PluginError{
+			PluginID:     pi.PluginID,
+			ErrorCode:    uint32(pi.ErrorCodeCommentWriteNotAllowed),
+			ErrorContext: "user is not the proposal author",
 		}
 	}
-	// New comment is a new thread but not a valid author update.
-	return backend.PluginError{
-		PluginID:     pi.PluginID,
-		ErrorCode:    uint32(pi.ErrorCodeVoteStatusInvalid),
-		ErrorContext: "vote has ended; comments are locked",
+
+	// Verify extra data fields
+	if n.ExtraDataHint != pi.ProposalUpdateHint {
+		return backend.PluginError{
+			PluginID:  pi.PluginID,
+			ErrorCode: uint32(pi.ErrorCodeExtraDataHintInvalid),
+			ErrorContext: fmt.Sprintf("got %v, want %v",
+				n.ExtraDataHint, pi.ProposalUpdateHint),
+		}
 	}
+	var pum pi.ProposalUpdateMetadata
+	err = json.Unmarshal([]byte(n.ExtraData), &pum)
+	if err != nil {
+		return backend.PluginError{
+			PluginID:  pi.PluginID,
+			ErrorCode: uint32(pi.ErrorCodeExtraDataInvalid),
+		}
+	}
+
+	// Verify update title
+	if !p.titleIsValid(pum.Title) {
+		return backend.PluginError{
+			PluginID:     pi.PluginID,
+			ErrorCode:    uint32(pi.ErrorCodeTitleInvalid),
+			ErrorContext: p.titleRegexp.String(),
+		}
+	}
+
+	// The comment is a valid author update.
+	return nil
 }
 
 // commentNewAllowedOnApprovedProposal verifies that the given new comment
@@ -566,7 +570,9 @@ func (p *piPlugin) commentNewAllowedOnApprovedProposal(token []byte, payload str
 		// is not allowed.
 		return backend.PluginError{
 			PluginID:  pi.PluginID,
-			ErrorCode: uint32(pi.ErrorCodeWritesAllowedOnlyOnUpdates),
+			ErrorCode: uint32(pi.ErrorCodeCommentWriteNotAllowed),
+			ErrorContext: "comment replies are only allowed on " +
+				"the author's most recent update thread",
 		}
 
 	default:
@@ -667,10 +673,9 @@ func (p *piPlugin) commentWritesAllowed(token []byte, cmd, payload string) error
 		// Vote status does not allow writes
 		return backend.PluginError{
 			PluginID:     pi.PluginID,
-			ErrorCode:    uint32(pi.ErrorCodeVoteStatusInvalid),
+			ErrorCode:    uint32(pi.ErrorCodeCommentWriteNotAllowed),
 			ErrorContext: "vote has ended; comments are locked",
 		}
-
 	}
 }
 

--- a/politeiad/backendv2/tstorebe/plugins/pi/hooks_test.go
+++ b/politeiad/backendv2/tstorebe/plugins/pi/hooks_test.go
@@ -484,7 +484,7 @@ func proposalNameTests(t *testing.T) []proposalFormatTest {
 	// fails.
 	errNameInvalid := backend.PluginError{
 		PluginID:  pi.PluginID,
-		ErrorCode: uint32(pi.ErrorCodeProposalNameInvalid),
+		ErrorCode: uint32(pi.ErrorCodeTitleInvalid),
 	}
 
 	return []proposalFormatTest{

--- a/politeiad/plugins/pi/pi.go
+++ b/politeiad/plugins/pi/pi.go
@@ -147,9 +147,9 @@ const (
 	// size exceedes the ImageFileSizeMax setting.
 	ErrorCodeImageFileSizeInvalid ErrorCodeT = 5
 
-	// ErrorCodeProposalNameInvalid is returned when a proposal name
-	// does not adhere to the proposal name settings.
-	ErrorCodeProposalNameInvalid ErrorCodeT = 6
+	// ErrorCodeTitleInvalid is returned when a title, proposal title or proposal
+	// update title, does not adhere to the title regexp requirements.
+	ErrorCodeTitleInvalid ErrorCodeT = 6
 
 	// ErrorCodeVoteStatusInvalid is returned when a proposal vote
 	// status does not allow changes to be made to the proposal.
@@ -194,17 +194,22 @@ const (
 	// is provided.
 	ErrorCodeBillingStatusInvalid = 16
 
-	// ErrorCodeUpdateTitleInvalid is returned when an update title
-	// does not adhere to the title setting.
-	ErrorCodeUpdateTitleInvalid = 17
+	// ErrorCodeCommentWriteNotAllowed is returned when a user attempts to submit
+	// a new comment or a comment vote, but does not have permission to. This
+	// could be because the proposal's vote status does not allow for any
+	// additional changes or because the user is trying to write to a thread
+	// that is not allowed. Example, once a proposal vote is approved the only
+	// comment writes that are allowed are replies to the author's most recent
+	// update thread and votes on comments within that thread.
+	ErrorCodeCommentWriteNotAllowed = 17
 
-	// ErrorCodeExtraDataHintInvalid is returned when the extra data hint
-	// is invalid.
+	// ErrorCodeExtraDataHintInvalid is returned when the extra data hint is
+	// invalid.
 	ErrorCodeExtraDataHintInvalid = 18
 
-	// ErrorCodeWritesAllowedOnlyOnUpdates is returned when the vote
-	// status allows comment writes only on author updates.
-	ErrorCodeWritesAllowedOnlyOnUpdates = 19
+	// ErrorCodeExtraDataInvalid is returned when the extra data payload is
+	// invalid.
+	ErrorCodeExtraDataInvalid = 19
 
 	// ErrorCodeLast unit test only.
 	ErrorCodeLast ErrorCodeT = 20
@@ -219,7 +224,7 @@ var (
 		ErrorCodeTextFileMissing:               "text file is misisng",
 		ErrorCodeImageFileCountInvalid:         "image file count invalid",
 		ErrorCodeImageFileSizeInvalid:          "image file size invalid",
-		ErrorCodeProposalNameInvalid:           "proposal name invalid",
+		ErrorCodeTitleInvalid:                  "title invalid",
 		ErrorCodeVoteStatusInvalid:             "vote status invalid",
 		ErrorCodeProposalAmountInvalid:         "proposal amount invalid",
 		ErrorCodeProposalStartDateInvalid:      "proposal start date invalid",
@@ -230,9 +235,9 @@ var (
 		ErrorCodeSignatureInvalid:              "signature invalid",
 		ErrorCodeBillingStatusChangeNotAllowed: "billing status change is not allowed",
 		ErrorCodeBillingStatusInvalid:          "billing status invalid",
-		ErrorCodeUpdateTitleInvalid:            "update title invalid",
+		ErrorCodeCommentWriteNotAllowed:        "comment write not allowed",
 		ErrorCodeExtraDataHintInvalid:          "extra data hint invalid",
-		ErrorCodeWritesAllowedOnlyOnUpdates:    "comment writes are allowed only on author updates",
+		ErrorCodeExtraDataInvalid:              "extra data payload invalid",
 	}
 )
 

--- a/politeiad/plugins/pi/pi.go
+++ b/politeiad/plugins/pi/pi.go
@@ -197,10 +197,10 @@ const (
 	// ErrorCodeCommentWriteNotAllowed is returned when a user attempts to submit
 	// a new comment or a comment vote, but does not have permission to. This
 	// could be because the proposal's vote status does not allow for any
-	// additional changes or because the user is trying to write to a thread
-	// that is not allowed. Example, once a proposal vote is approved the only
-	// comment writes that are allowed are replies to the author's most recent
-	// update thread and votes on comments within that thread.
+	// additional changes or because the user is trying to write to a thread that
+	// is not allowed. Example, once a proposal vote is approved the only comment
+	// writes that are allowed are replies and votes to the author's most recent
+	// update thread.
 	ErrorCodeCommentWriteNotAllowed = 17
 
 	// ErrorCodeExtraDataHintInvalid is returned when the extra data hint is


### PR DESCRIPTION
This diff makes the following changes:

- Removes the unnecessary nesting in isValidAuthorUpdate.

- Adds a ExtraDataInvalid plugin error and returns this error in the
  appropriate place.

- Adds a generic CommentWriteNotAllowed plugin error that can be re-used
  in various error paths. The specific reason the comment write is not
  allowed is returned in the ErrorContext.

- Returns a more specific plugin error for an update that is not
  submitted by the record author.

- Adds a more specific error context to the ExtraDataHintInvalid error
  path.

- Updates the ProposalNameInvalid plugin error to be a more generic
  TitleInvalid error in order to match the plugin settings.