### PR TITLE
Tweak logic.

### DIFF
--- a/politeiad/backendv2/tstorebe/plugins/pi/proposalstatus.go
+++ b/politeiad/backendv2/tstorebe/plugins/pi/proposalstatus.go
@@ -87,7 +87,7 @@ func (p *piPlugin) getProposalStatus(token []byte) (pi.PropStatusT, error) {
 	if statusRequiresBillingStatuses(voteStatus) {
 		// If the maximum allowed number of billing status changes
 		// have already been made for this proposal and those results
-		// have been cached, then we don't need to retreive anything
+		// have been cached, then we don't need to retrieve anything
 		// else. The proposal status cannot be changed any further.
 		if uint32(billingStatusesCount) >= p.billingStatusChangesMax {
 			return propStatus, nil

--- a/politeiad/backendv2/tstorebe/plugins/pi/proposalstatus.go
+++ b/politeiad/backendv2/tstorebe/plugins/pi/proposalstatus.go
@@ -84,7 +84,7 @@ func (p *piPlugin) getProposalStatus(token []byte) (pi.PropStatusT, error) {
 	voteStatus = vs.Status
 
 	// Get the billing statuses if required
-	if requiresBillingStatuses(voteStatus) {
+	if statusRequiresBillingStatuses(voteStatus) {
 		// If the maximum allowed number of billing status changes
 		// have already been made for this proposal and those results
 		// have been cached, then we don't need to retreive anything
@@ -168,7 +168,7 @@ func statusRequiresRecord(s pi.PropStatusT) bool {
 // statusRequiresBillingStatuses returns whether the proposal requires the
 // billing status changes to be retrieved. This is necessary when the proposal
 // is in a stage where it's billing status can still change.
-func requiresBillingStatuses(vs ticketvote.VoteStatusT) bool {
+func statusRequiresBillingStatuses(vs ticketvote.VoteStatusT) bool {
 	switch vs {
 	case ticketvote.VoteStatusUnauthorized,
 		ticketvote.VoteStatusAuthorized,

--- a/politeiad/backendv2/tstorebe/plugins/pi/proposalstatus.go
+++ b/politeiad/backendv2/tstorebe/plugins/pi/proposalstatus.go
@@ -70,7 +70,6 @@ func (p *piPlugin) getProposalStatus(token []byte) (pi.PropStatusT, error) {
 		// determine the proposal status.
 		recordState = r.RecordMetadata.State
 		recordStatus = r.RecordMetadata.Status
-		voteStatus = ticketvote.VoteStatusInvalid
 
 		// Pull the vote metadata out of the record files
 		voteMetadata, err = voteMetadataDecode(r.Files)

--- a/politeiad/backendv2/tstorebe/plugins/pi/proposalstatus.go
+++ b/politeiad/backendv2/tstorebe/plugins/pi/proposalstatus.go
@@ -88,7 +88,7 @@ func (p *piPlugin) getProposalStatus(token []byte) (pi.PropStatusT, error) {
 		// If the maximum allowed number of billing status changes
 		// have already been made for this proposal and those results
 		// have been cached, then we don't need to retreive anything
-		// else. The proposal status cannot change any further.
+		// else. The proposal status cannot be changed any further.
 		if uint32(billingStatusesCount) >= p.billingStatusChangesMax {
 			return propStatus, nil
 		}

--- a/politeiad/backendv2/tstorebe/plugins/pi/statusescache.go
+++ b/politeiad/backendv2/tstorebe/plugins/pi/statusescache.go
@@ -20,10 +20,11 @@ type statusEntry struct {
 
 	// The following fields cache data in order to reduce the number of backend
 	// calls required to determine the proposal status.
-	recordState  backend.StateT
-	recordStatus backend.StatusT
-	voteStatus   ticketvote.VoteStatusT
-	voteMetadata *ticketvote.VoteMetadata
+	recordState          backend.StateT
+	recordStatus         backend.StatusT
+	voteStatus           ticketvote.VoteStatusT
+	voteMetadata         *ticketvote.VoteMetadata
+	billingStatusesCount int // Number of billing status changes
 }
 
 // statusesCacheLimit is the cache's default maximum capacity. Note that it's


### PR DESCRIPTION
Using your branch, a proposal with an `active` status will result in a single call to retrieve the billing statuses.  This is considerably better than the previous logic, which resulted in a records call, a vote summary call, and a billing statuses call.

A proposal with an `under-discussion` status will result in a records call, a vote summary call, and a billing statuses call.

The goal is to reduce the number of times the full tlog tree needs to be retrieved.  The records call and the billing statuses call both cause a tree retrieval.  The vote summary is cached data and does not cause a tree retrieval.  The logic changes I've made in this PR will add a vote summary call to certain proposal statuses, like `active`, but will remove the billing statuses call from statuses that don't need it, like `under-discussion`.  This is a tradeoff worth being made since the tlog tree retrievals are far more expensive than a vote summary cache lookup. 

It also caches the number of billing status changes so that we can skip the billing status changes call if the proposal has reached the maximum limit that is set by the config.
