### PR TITLE
Convert command refactor #1.

### DIFF
--- a/politeiad/cmd/legacypoliteia/convert.go
+++ b/politeiad/cmd/legacypoliteia/convert.go
@@ -60,6 +60,10 @@ func convertRecordMetadata(proposalDir string) (*backend.RecordMetadata, error) 
 
 	// Build record metadata
 	rm := backend.RecordMetadata{
+		// We are using the legacy git token as the record
+		// metadata token for the sake of keeping certain
+		// signatures coherent (I think...). This needs to
+		// be verified.
 		Token:     r.Token,
 		Version:   uint32(version),
 		Iteration: uint32(r.Iteration),
@@ -69,9 +73,13 @@ func convertRecordMetadata(proposalDir string) (*backend.RecordMetadata, error) 
 		Merkle:    r.Merkle,
 	}
 
-	fmt.Printf("    Token  : %v\n", rm.Token)
-	fmt.Printf("    Version: %v\n", rm.Version)
-	fmt.Printf("    Status : %v\n", backend.Statuses[rm.Status])
+	fmt.Printf("    Token    : %v\n", rm.Token)
+	fmt.Printf("    Version  : %v\n", rm.Version)
+	fmt.Printf("    Iteration: %v\n", rm.Iteration)
+	fmt.Printf("    State    : %v\n", backend.States[rm.State])
+	fmt.Printf("    Status   : %v\n", backend.Statuses[rm.Status])
+	fmt.Printf("    Timestamp: %v\n", rm.Timestamp)
+	fmt.Printf("    Merkle   : %v\n", rm.Merkle)
 
 	return &rm, nil
 }

--- a/politeiad/cmd/legacypoliteia/convert.go
+++ b/politeiad/cmd/legacypoliteia/convert.go
@@ -229,7 +229,7 @@ func (c *convertCmd) convertUserMetadata(proposalDir string) (*usermd.UserMetada
 	}
 
 	// Populate the user ID. The user ID was not saved
-	// to disk in the git backend, so we must retreive
+	// to disk in the git backend, so we must retrieve
 	// it from the politeia API using the public key.
 	userID, err := c.getUserIDByPubKey(p.PublicKey)
 	if err != nil {

--- a/politeiad/cmd/legacypoliteia/convert.go
+++ b/politeiad/cmd/legacypoliteia/convert.go
@@ -137,14 +137,15 @@ func convertProposalMetadata(proposalDir string) (*pi.ProposalMetadata, error) {
 		return nil, err
 	}
 
-	fmt.Printf("    Name: %v\n", name)
-
 	// Get the legacy token from the proposal
 	// directory path.
 	token, ok := gitProposalToken(proposalDir)
 	if !ok {
 		return nil, fmt.Errorf("token not found in path '%v'", proposalDir)
 	}
+
+	fmt.Printf("    Name       : %v\n", name)
+	fmt.Printf("    LegacyToken: %v\n", token)
 
 	return &pi.ProposalMetadata{
 		Name:        name,

--- a/politeiad/cmd/legacypoliteia/convert.go
+++ b/politeiad/cmd/legacypoliteia/convert.go
@@ -210,22 +210,11 @@ func (c *convertCmd) populateUserID(userMD *usermd.UserMetadata) error {
 }
 
 func (c *convertCmd) getUserID(userPubKey string) (string, error) {
-	switch {
-	case c.userID != "":
-		// Replacement user ID is not empty, use it
-		return c.userID, nil
-
-	case c.userID == "":
-		// No replacement user ID is given, pull user ID using the
-		// present public key.
-		u, err := c.fetchUserByPubKey(userPubKey)
-		if err != nil {
-			return "", err
-		}
-		return u.ID, nil
+	u, err := c.fetchUserByPubKey(userPubKey)
+	if err != nil {
+		return "", err
 	}
-
-	return "", nil
+	return u.ID, nil
 }
 
 // convertUserMetadata reads the git backend data from disk that is

--- a/politeiad/cmd/legacypoliteia/convert.go
+++ b/politeiad/cmd/legacypoliteia/convert.go
@@ -250,6 +250,8 @@ func (c *convertCmd) convertUserMetadata(proposalDir string) (*usermd.UserMetada
 // convertStatusChange reads the git backend data from disk that is
 // required to build the usermd plugin StatusChangeMetadata structures,
 // then returns the latest StateChangeMetadata.
+//
+// Only the most recent status change is returned.
 func convertStatusChange(proposalDir string) (*usermd.StatusChangeMetadata, error) {
 	fmt.Printf("  Status changes\n")
 
@@ -297,9 +299,6 @@ func convertStatusChange(proposalDir string) (*usermd.StatusChangeMetadata, erro
 			Timestamp: sc.Timestamp,
 		}
 
-		fmt.Printf("    Status: %v\n", backend.Statuses[status])
-		fmt.Printf("    Reason: %v\n", scm.Reason)
-
 		statuses = append(statuses, scm)
 	}
 
@@ -308,8 +307,19 @@ func convertStatusChange(proposalDir string) (*usermd.StatusChangeMetadata, erro
 		return statuses[i].Timestamp < statuses[j].Timestamp
 	})
 
-	latestStatusChange := statuses[len(statuses)-1]
-	return &latestStatusChange, nil
+	// Only the most recent status change is returned
+	latest := statuses[len(statuses)-1]
+
+	status := backend.StatusT(latest.Status)
+	fmt.Printf("    Token    : %v\n", latest.Token)
+	fmt.Printf("    Version  : %v\n", latest.Version)
+	fmt.Printf("    Status   : %v\n", backend.Statuses[status])
+	fmt.Printf("    PublicKey: %v\n", latest.PublicKey)
+	fmt.Printf("    Signature: %v\n", latest.Signature)
+	fmt.Printf("    Reason   : %v\n", latest.Reason)
+	fmt.Printf("    Timestamp: %v\n", latest.Timestamp)
+
+	return &latest, nil
 }
 
 // convertAuthDetails reads the git backend data from disk that is

--- a/politeiad/cmd/legacypoliteia/convertcmd.go
+++ b/politeiad/cmd/legacypoliteia/convertcmd.go
@@ -21,7 +21,6 @@ import (
 	"github.com/decred/politeia/politeiad/plugins/ticketvote"
 	"github.com/decred/politeia/politeiawww/client"
 	"github.com/decred/politeia/util"
-	"github.com/google/uuid"
 )
 
 const (
@@ -41,7 +40,6 @@ var (
 	skipComments = convertFlags.Bool("skipcomments", false, "skip comments")
 	skipBallots  = convertFlags.Bool("skipballots", false, "skip ballots")
 	ballotLimit  = convertFlags.Int("ballotlimit", 0, "limit parsed votes")
-	userID       = convertFlags.String("userid", "", "replace user IDs")
 	token        = convertFlags.String("token", "", "test one proposal at a time")
 )
 
@@ -52,7 +50,6 @@ type convertCmd struct {
 	skipComments bool
 	skipBallots  bool
 	ballotLimit  int
-	userID       string
 	token        string
 }
 
@@ -80,14 +77,6 @@ func execConvertCmd(args []string) error {
 	// Clean the legacy directory path
 	*legacyDir = util.CleanAndExpandPath(*legacyDir)
 
-	// Verify the user ID
-	if *userID != "" {
-		_, err = uuid.Parse(*userID)
-		if err != nil {
-			return fmt.Errorf("invalid user id '%v': %v", *userID, err)
-		}
-	}
-
 	// Setup the legacy directory
 	err = os.MkdirAll(*legacyDir, filePermissions)
 	if err != nil {
@@ -107,7 +96,6 @@ func execConvertCmd(args []string) error {
 		skipComments: *skipComments,
 		skipBallots:  *skipBallots,
 		ballotLimit:  *ballotLimit,
-		userID:       *userID,
 		token:        *token,
 	}
 

--- a/politeiad/cmd/legacypoliteia/politeia.go
+++ b/politeiad/cmd/legacypoliteia/politeia.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2022 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+)
+
+// politeia.go contains all API requests to the politeia API.
+
+const (
+	politeiaHost = "https://proposals.decred.org/api"
+)
+
+// getUserIDByPubKey retrieves the user ID from the politeia API for the
+// provided public key and returns it.
+func (c *convertCmd) getUserIDByPubKey(userPubKey string) (string, error) {
+	u, err := c.getUserByPubKey(userPubKey)
+	if err != nil {
+		return "", err
+	}
+	return u.ID, nil
+}
+
+// userReply is politeiawww's reply to the users request.
+type usersReply struct {
+	TotalUsers   uint64 `json:"totalusers,omitempty"`
+	TotalMatches uint64 `json:"totalmatches"`
+	Users        []user `json:"users"`
+}
+
+// user is returned from the politeiawww API.
+type user struct {
+	ID       string `json:"id"`
+	Email    string `json:"email,omitempty"`
+	Username string `json:"username"`
+}
+
+// getUserByPubKey makes a call to the politeia API requesting the user
+// with the provided public key.
+func (c *convertCmd) getUserByPubKey(pubkey string) (*user, error) {
+	url := politeiaHost + "/v1/users?publickey=" + pubkey
+	r, err := c.client.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer r.Body.Close()
+
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var ur usersReply
+	err = json.Unmarshal(body, &ur)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(ur.Users) == 0 {
+		return nil, fmt.Errorf("no user found for pubkey %v", pubkey)
+	}
+
+	return &ur.Users[0], nil
+}

--- a/politeiad/cmd/legacypoliteia/usage.go
+++ b/politeiad/cmd/legacypoliteia/usage.go
@@ -31,7 +31,5 @@ Command Usage
                             being parsed. When the ballots are limited we avoid
                             fetching the git timestamps to speed up testing.
                             (default: 0)											
-    --userid       (string) Replace the user IDs in the parsed data with the
-                            provided user ID. (default: "")
     --token        (string) Specify a single token whose contents will be 
                             converted and saved to disk. (default: "")`


### PR DESCRIPTION
- Remove userid CLI flag.
- Tweak proposal token logging.
- Move the politeia API calls into a separate file called politeia.go.
- Small refactors of convertUserMetadata, convertRecordMetadata, convertProposalMetadata, convertStatusChange.